### PR TITLE
First pass at suffix_arrays in arkouda-njit

### DIFF
--- a/client/suffix_array/sa_benchmark.py
+++ b/client/suffix_array/sa_benchmark.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import time
+import argparse
+import arkouda as ak
+import random
+import string
+
+TYPES = ('int64', 'float64', 'bool', 'str')
+
+
+def time_ak_sa(vsize, strlen, trials, dtype):
+    print(">>> arkouda suffix array")
+    cfg = ak.get_config()
+    Nv = vsize * cfg["numLocales"]
+    print("numLocales = {},  num of strings  = {:,}".format(cfg["numLocales"], Nv))
+
+    if dtype == 'str':
+        v = ak.random_strings_uniform(1, strlen, Nv)
+    else:
+        print("Wrong data type")
+    c = ak.suffix_array(v)
+    print("All the random strings are as follows")
+    for k in range(vsize):
+        print("the {} th random tring ={}".format(k, v[k]))
+        print("the {} th suffix array ={}".format(k, c[k]))
+        print("")
+    timings = []
+    for _ in range(trials):
+        start = time.time()
+        c = ak.suffix_array(v)
+        end = time.time()
+        timings.append(end - start)
+    tavg = sum(timings) / trials
+
+    print("Average time = {:.4f} sec".format(tavg))
+    if dtype == 'str':
+        offsets_transferred = 0 * c.offsets.size * c.offsets.itemsize
+        bytes_transferred = (c.bytes.size * c.offsets.itemsize) + (0 * c.bytes.size)
+        bytes_per_sec = (offsets_transferred + bytes_transferred) / tavg
+    else:
+        print("Wrong data type")
+    print("Average rate = {:.2f} GiB/sec".format(bytes_per_sec/2**30))
+
+
+def suffixArray(s):
+    suffixes = [(s[i:], i) for i in range(len(s))]
+    suffixes.sort(key=lambda x: x[0])
+    sa = [s[1] for s in suffixes]
+    return sa
+
+
+def time_np_sa(vsize, strlen, trials, dtype):
+    s = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(strlen))
+    timings = []
+    for _ in range(trials):
+        start = time.time()
+        sa = suffixArray(s)
+        end = time.time()
+        timings.append(end - start)
+    tavg = sum(timings) / trials
+    print("Average time = {:.4f} sec".format(tavg))
+    if dtype == 'str':
+        offsets_transferred = 0
+        bytes_transferred = len(s)
+        bytes_per_sec = (offsets_transferred + bytes_transferred) / tavg
+    else:
+        print("Wrong data type")
+    print("Average rate = {:.2f} GiB/sec".format(bytes_per_sec/2**30))
+
+
+def check_correctness( vsize,strlen, trials, dtype):
+    Ni = strlen
+    Nv = vsize
+
+    v = ak.random_strings_uniform(1, Ni, Nv)
+    c = ak.suffix_array(v)
+    for k in range(Nv):
+        s = v[k]
+        sa = suffixArray(s)
+        aksa = c[k]
+        assert sa == aksa
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Measure the performance of suffix array building: C= suffix_array(V)")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10**4, help='Problem size: length of strings')
+    parser.add_argument('-v', '--number', type=int, default=10,help='Number of strings')
+    parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
+    parser.add_argument('-d', '--dtype', default='str', help='Dtype of value array ({})'.format(', '.join(TYPES)))
+    parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
+    parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Use random values instead of ones')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
+    return parser
+
+
+if __name__ == "__main__":
+    import sys
+    parser = create_parser()
+    args = parser.parse_args()
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        check_correctness(args.number, args.size, args.trials, args.dtype)
+        print("CORRECT")
+        sys.exit(0)
+
+    print("length of strings = {:,}".format(args.size))
+    print("number of strings = {:,}".format(args.number))
+    print("number of trials = ", args.trials)
+    time_ak_sa(args.number, args.size, args.trials, args.dtype)
+    if args.numpy:
+        time_np_sa(args.number, args.size, args.trials, args.dtype)
+    sys.exit(0)

--- a/client/suffix_array/suffix_array.py
+++ b/client/suffix_array/suffix_array.py
@@ -1,0 +1,755 @@
+from __future__ import annotations
+
+import itertools
+from typing import cast, List, Optional, Union
+from typeguard import typechecked
+from arkouda.client import generic_msg
+from arkouda.pdarrayclass import pdarray, create_pdarray, \
+    unregister_pdarray_by_name, RegistrationError
+from arkouda.strings import Strings
+from arkouda.logger import getArkoudaLogger
+import numpy as np  # type: ignore
+from arkouda.dtypes import resolve_scalar_dtype, translate_np_dtype, int64
+import json
+from arkouda.infoclass import information
+from arkouda.dtypes import dtype
+from arkouda.dtypes import int64 as akint64
+from arkouda.pdarraysetops import in1d
+
+__all__ = ["SArrays", "suffix_array", "lcp_array", "suffix_array_file"]
+
+
+def _parse_single_int_array_value(msg: str) -> object:
+    """
+    Attempt to convert a scalar return value from the arkouda server to a
+    numpy string in Python. The user should not call this function directly.
+
+    Parameters
+    ----------
+    msg : str
+        scalar value in string form to be converted to a numpy string
+
+    Returns
+    -------
+    object numpy scalar
+    """
+    dtname, value = msg.split(maxsplit=1)
+    mydtype = dtype(dtname)
+    try:
+        if mydtype == akint64:
+            nfields = value.split("\"")
+            # original we return a string include the last ending 0
+
+            _, sastr = nfields[1].split(maxsplit=1)
+            tmpstr = sastr.split()
+            intary = [int(numeric_string) for numeric_string in tmpstr]
+            return intary
+            # now we return a suffix array and not include the last ending 0
+        else:
+            raise ValueError(("not correct int data type from server {} {}".format(mydtype.name, value)))
+    except Exception as e:
+        raise ValueError(e)
+
+
+def in1d_int(pda1: Union[pdarray, SArrays, 'Categorical'], pda2: Union[pdarray, SArrays, 'Categorical'],  # type: ignore
+             invert: bool = False) -> pdarray:
+    """
+    Test whether each element of a 1-D array is also present in a second array.
+
+    Returns a boolean array the same length as `pda1` that is True
+    where an element of `pda1` is in `pda2` and False otherwise.
+
+    Parameters
+    ----------
+    pda1 : pdarray or SArrays or Categorical
+        Input array.
+    pda2 : pdarray or SArrays or Categorical
+        The values against which to test each value of `pda1`. Must be the
+        same type as `pda1`.
+    invert : bool, optional
+        If True, the values in the returned array are inverted (that is,
+        False where an element of `pda1` is in `pda2` and True otherwise).
+        Default is False. ``ak.in1d(a, b, invert=True)`` is equivalent
+        to (but is faster than) ``~ak.in1d(a, b)``.
+
+    Returns
+    -------
+    pdarray, bool
+        The values `pda1[in1d]` are in `pda2`.
+
+    Raises
+    ------
+    TypeError
+        Raised if either pda1 or pda2 is not a pdarray, Strings, or
+        Categorical object or if invert is not a bool
+    RuntimeError
+        Raised if the dtype of either array is not supported
+
+    See Also
+    --------
+    unique, intersect1d, union1d
+
+    Notes
+    -----
+    `in1d` can be considered as an element-wise function version of the
+    python keyword `in`, for 1-D sequences. ``in1d(a, b)`` is logically
+    equivalent to ``ak.array([item in b for item in a])``, but is much
+    faster and scales to arbitrarily large ``a``.
+
+    ak.in1d is not supported for bool or float64 pdarrays
+
+    Examples
+    --------
+    >>> ak.in1d(ak.array([-1, 0, 1]), ak.array([-2, 0, 2]))
+    array([False, True, False])
+
+    >>> ak.in1d(ak.array(['one','two']),ak.array(['two', 'three','four','five']))
+    array([False, True])
+    """
+    if isinstance(pda1, SArrays) and isinstance(pda2, SArrays):
+        repMsg = generic_msg(
+            "segmentedIn1dInt {} {} {} {} {} {} {}".format(
+                pda1.objtype,
+                pda1.offsets.name,
+                pda1.bytes.name,
+                pda2.objtype,
+                pda2.offsets.name,
+                pda2.bytes.name,
+                invert,
+            )
+        )
+        return create_pdarray(cast(str, repMsg))
+    else:
+        return in1d(pda1, pda2)
+
+
+class SArrays:
+    """
+    Represents an array of (suffix) arrays whose data resides on the arkouda server.
+    The user should not call this class directly; rather its instances are created
+    by other arkouda functions. It is very similar to Strings and the difference is
+    that its content is int arrays instead of strings.
+
+    Attributes
+    ----------
+    offsets : pdarray
+        The starting indices for each suffix array
+    bytes : pdarray
+        The raw integer indices of all suffix arrays
+    size : int
+        The number of suffix arrays in the array
+    nbytes : int
+        The total number of indices in all suffix arrays
+        We have the same number indices as the number of characters/suffixes in strings
+    ndim : int
+        The rank of the array (currently only rank 1 arrays supported)
+    shape : tuple
+        The sizes of each dimension of the array
+    dtype : dtype
+        The dtype is np.int
+    logger : ArkoudaLogger
+        Used for all logging operations
+
+    Notes
+    -----
+    SArrays is composed of two pdarrays: (1) offsets, which contains the
+    starting indices for each string's suffix array  and (2) bytes, which contains the
+    indices of all suffix arrays, no any spliter between two index arrays.
+    """
+
+    BinOps = frozenset(["==", "!="])
+    objtype = "int"
+
+    def __init__(
+        self,
+        offset_attrib: Union[pdarray, np.ndarray],
+        bytes_attrib: Union[pdarray, np.ndarray],
+    ):
+        """
+        Initializes the SArrays instance by setting all instance
+        attributes, some of which are derived from the array parameters.
+
+        Parameters
+        ----------
+        offset_attrib : Union[pdarray, np.ndarray,array]
+            the array containing the offsets
+        bytes_attrib : Union[pdarray, np.ndarray,array]
+            the array containing the suffix array indices
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there's an error converting a Numpy array or standard
+            Python array to either the offset_attrib or bytes_attrib
+        ValueError
+            Raised if there's an error in generating instance attributes
+            from either the offset_attrib or bytes_attrib parameter
+        """
+        if isinstance(offset_attrib, pdarray):
+            self.offsets = offset_attrib
+        else:
+            try:
+                self.offsets = create_pdarray(offset_attrib)
+            except Exception as e:
+                raise RuntimeError(e)
+        if isinstance(bytes_attrib, pdarray):
+            self.bytes = bytes_attrib
+        else:
+            try:
+                self.bytes = create_pdarray(bytes_attrib)
+            except Exception as e:
+                raise RuntimeError(e)
+        try:
+            self.size = self.offsets.size
+            self.nbytes = self.bytes.size
+            self.ndim = self.offsets.ndim
+            self.shape = self.offsets.shape
+        except Exception as e:
+            raise ValueError(e)
+        self.dtype = int64
+        self.name: Optional[str] = None
+        self.logger = getArkoudaLogger(name=__class__.__name__)  # type: ignore
+
+    def __iter__(self):
+        raise NotImplementedError('SArrays does not support iteration. To force data transfer from server, use to_ndarray')
+
+    def __len__(self) -> int:
+        return self.shape[0]
+
+    def __str__(self) -> str:
+        from arkouda.client import pdarrayIterThresh
+        if self.size <= pdarrayIterThresh:
+            vals = ["'{}'".format(self[i]) for i in range(self.size)]
+        else:
+            vals = ["'{}'".format(self[i]) for i in range(3)]
+            vals.append("... ")
+            vals.extend([self[i] for i in range(self.size - 3, self.size)])
+        return "[{}]".format(", ".join(vals))
+
+    def __repr__(self) -> str:
+        return "array({})".format(self.__str__())
+
+    @typechecked
+    def _binop(self, other: Union[SArrays, np.int_], op: str) -> pdarray:
+        """
+        Executes the requested binop on this SArrays instance and the
+        parameter SArrays object and returns the results within
+        a pdarray object.
+
+        Parameters
+        ----------
+        other : SArrays
+            the other object is a SArrays object
+        op : str
+            name of the binary operation to be performed
+
+        Returns
+        -------
+        pdarray
+            encapsulating the results of the requested binop
+
+        Raises
+        -----
+        ValueError
+            Raised if (1) the op is not in the self.BinOps set, or (2) if the
+            sizes of this and the other instance don't match, or (3) the other
+            object is not a SArrays object
+        RuntimeError
+            Raised if a server-side error is thrown while executing the
+            binary operation
+        """
+        if op not in self.BinOps:
+            raise ValueError("SArrays: unsupported operator: {}".format(op))
+        if isinstance(other, Strings):
+            if self.size != other.size:
+                raise ValueError(
+                    "SArrays: size mismatch {} {}".format(self.size, other.size)
+                )
+            cmd = "segmentedBinopvvInt"
+            args = "{} {} {} {} {} {} {}".format(
+                op,
+                self.objtype,
+                self.offsets.name,
+                self.bytes.name,
+                other.objtype,
+                other.offsets.name,
+                other.bytes.name,
+            )
+        elif resolve_scalar_dtype(other) == "int":
+            cmd = "segmentedBinopvsInt"
+            args = "{} {} {} {} {} {}".format(
+                op,
+                self.objtype,
+                self.offsets.name,
+                self.bytes.name,
+                self.objtype,
+                json.dumps([other]),
+            )
+        else:
+            raise ValueError(
+                "SArrays: {} not supported between SArrays and {}".format(
+                    op, other.__class__.__name__
+                )
+            )
+        repMsg = generic_msg(cmd=cmd, args=args)
+        return create_pdarray(cast(str, repMsg))
+
+    def __eq__(self, other) -> bool:
+        return self._binop(other, "==")
+
+    def __ne__(self, other) -> bool:
+        return self._binop(cast(SArrays, other), "!=")
+
+    def __getitem__(self, key):
+        if np.isscalar(key) and resolve_scalar_dtype(key) == "int64":
+            orig_key = key
+            if key < 0:
+                # Interpret negative key as offset from end of array
+                key += self.size
+            if key >= 0 and key < self.size:
+                cmd = "segmentedIntIndex"
+                args = "{} {} {} {} {}".format(
+                    "intIndex", self.objtype, self.offsets.name, self.bytes.name, key
+                )
+                repMsg = generic_msg(cmd=cmd, args=args)
+                _, value = repMsg.split(maxsplit=1)
+                return _parse_single_int_array_value(value)
+            else:
+                raise IndexError(
+                    "[int] {} is out of bounds with size {}".format(orig_key, self.size)
+                )
+        elif isinstance(key, slice):
+            (start, stop, stride) = key.indices(self.size)
+            self.logger.debug(
+                "start: {}; stop: {}; stride: {}".format(start, stop, stride)
+            )
+            cmd = "segmentedIntIndex"
+            args = "{} {} {} {} {} {} {}".format(
+                "sliceIndex",
+                self.objtype,
+                self.offsets.name,
+                self.bytes.name,
+                start,
+                stop,
+                stride,
+            )
+            repMsg = generic_msg(cmd=cmd, args=args)
+            offsets, values = repMsg.split("+")
+            return SArrays(offsets, values)
+        elif isinstance(key, pdarray):
+            kind, _ = translate_np_dtype(key.dtype)
+            if kind not in ("bool", "int"):
+                raise TypeError("unsupported pdarray index type {}".format(key.dtype))
+            if kind == "int" and self.size != key.size:
+                raise ValueError("size mismatch {} {}".format(self.size, key.size))
+            cmd = "segmentedIntIndex"
+            args = "{} {} {} {} {}".format(
+                "pdarrayIndex",
+                self.objtype,
+                self.offsets.name,
+                self.bytes.name,
+                key.name,
+            )
+            repMsg = generic_msg(cmd=cmd, args=args)
+            offsets, values = repMsg.split("+")
+            return SArrays(offsets, values)
+        else:
+            raise TypeError(
+                "unsupported pdarray index type {}".format(key.__class__.__name__)
+            )
+
+    def get_lengths(self) -> pdarray:
+        """
+        Return the length of each suffix array in the array.
+
+        Returns
+        -------
+        pdarray, int
+            The length of each string
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error thrown
+        """
+        cmd = "segmentIntLengths"
+        args = "{} {} {}".format(self.objtype, self.offsets.name, self.bytes.name)
+        repMsg = generic_msg(cmd=cmd, args=args)
+        return create_pdarray(cast(str, repMsg))
+
+    def save(
+        self, prefix_path: str, dataset: str = "int_array", mode: str = "truncate"
+    ) -> None:
+        """
+        Save the SArrays object to HDF5. The result is a collection of HDF5 files,
+        one file per locale of the arkouda server, where each filename starts
+        with prefix_path. Each locale saves its chunk of the array to its
+        corresponding file.
+
+        Parameters
+        ----------
+        prefix_path : str
+            Directory and filename prefix that all output files share
+        dataset : str
+            The name of the SArrays dataset to be written, defaults to int_array
+        mode : str {'truncate' | 'append'}
+            By default, truncate (overwrite) output files, if they exist.
+            If 'append', create a new SArrays dataset within existing files.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            Raised if the lengths of columns and values differ, or the mode is
+            neither 'truncate' nor 'append'
+
+        See Also
+        --------
+        pdarrayIO.save
+
+        Notes
+        -----
+        Important implementation notes: (1) SArrays state is saved as two datasets
+        within an hdf5 group, (2) the hdf5 group is named via the dataset parameter,
+        (3) the hdf5 group encompasses the two pdarrays composing a SArrays object:
+        segments and values and (4) save logic is delegated to pdarray.save
+        """
+        self.bytes.save(
+            prefix_path=prefix_path, dataset="{}/values".format(dataset), mode=mode
+        )
+
+    def is_registered(self) -> np.bool_:
+        """
+        Return True iff the object is contained in the registry
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        bool
+            Indicates if the object is contained in the registry
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there's a server-side error thrown
+        """
+        parts_registered = [np.bool_(self.offsets.is_registered()), self.bytes.is_registered()]
+        if np.any(parts_registered) and not np.all(parts_registered):  # test for error
+            raise RegistrationError(f"Not all registerable components of SuffixArray {self.name} are registered.")
+
+        return np.bool_(np.any(parts_registered))
+
+    def _list_component_names(self) -> List[str]:
+        """
+        Internal Function that returns a list of all component names
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        List[str]
+            List of all component names
+        """
+        return list(
+            itertools.chain.from_iterable([self.offsets._list_component_names(), self.bytes._list_component_names()]))
+
+    def info(self) -> str:
+        """
+        Returns a JSON formatted string containing information about all components of self
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        str
+            JSON string containing information about all components of self
+        """
+        return information(self._list_component_names())
+
+    def pretty_print_info(self) -> None:
+        """
+        Prints information about all components of self in a human readable format
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+        """
+        self.offsets.pretty_print_info()
+        self.bytes.pretty_print_info()
+
+    @typechecked
+    def register(self, user_defined_name: str) -> SArrays:
+        """
+        Register this SArrays object with a user defined name in the arkouda server
+        so it can be attached to later using SArrays.attach()
+        This is an in-place operation, registering a SArrays object more than once will
+        update the name in the registry and remove the previously registered name.
+        A name can only be registered to one object at a time.
+
+        Parameters
+        ----------
+        user_defined_name : str
+            user defined name which the SArrays object is to be registered under
+
+        Returns
+        -------
+        SArrays
+            The same SArrays object which is now registered with the arkouda server and has an updated name.
+            This is an in-place modification, the original is returned to support a fluid programming style.
+            Please note you cannot register two different objects with the same name.
+
+        Raises
+        ------
+        TypeError
+            Raised if user_defined_name is not a str
+        RegistrationError
+            If the server was unable to register the SArrays object with the user_defined_name
+            If the user is attempting to register more than one object with the same name, the former should be
+            unregistered first to free up the registration name.
+
+        See also
+        --------
+        attach, unregister
+
+        Notes
+        -----
+        Registered names/SArrays objects in the server are immune to deletion
+        until they are unregistered.
+        """
+        self.offsets.register(f"{user_defined_name}.offsets")
+        self.bytes.register(f"{user_defined_name}.bytes")
+        self.name = user_defined_name
+        return self
+
+    def unregister(self) -> None:
+        """
+        Unregister a SArrays object in the arkouda server which was previously
+        registered using register() and/or attached to using attach()
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        RuntimeError
+            Raised if the server could not find the internal name/symbol to remove
+
+        See also
+        --------
+        register, attach
+
+        Notes
+        -----
+        Registered names/SArrays objects in the server are immune to deletion until
+        they are unregistered.
+        """
+        self.offsets.unregister()
+        self.bytes.unregister()
+        self.name = None
+
+    @staticmethod
+    @typechecked
+    def attach(user_defined_name: str) -> SArrays:
+        """
+        class method to return a SArrays object attached to the registered name in the arkouda
+        server which was registered using register()
+
+        Parameters
+        ----------
+        user_defined_name : str
+            user defined name which the SArrays object was registered under
+
+        Returns
+        -------
+        SArrays object
+            the SArrays object registered with user_defined_name in the arkouda server
+
+        Raises
+        ------
+        TypeError
+            Raised if user_defined_name is not a str
+
+        See also
+        --------
+        register, unregister
+
+        Notes
+        -----
+        Registered names/SArrays objects in the server are immune to deletion
+        until they are unregistered.
+        """
+        s = SArrays(pdarray.attach(f"{user_defined_name}.offsets"),
+                    pdarray.attach(f"{user_defined_name}.bytes"))
+        s.name = user_defined_name
+        return s
+
+    @staticmethod
+    @typechecked
+    def unregister_sarrays_by_name(user_defined_name: str) -> None:
+        """
+        Unregister a SArrays object in the arkouda server previously registered via register()
+
+        Parameters
+        ----------
+        user_defined_name : str
+            The registered name of the SArrays object
+
+        See also
+        --------
+        register, unregister, attach, is_registered
+        """
+        unregister_pdarray_by_name(f"{user_defined_name}.bytes")
+        unregister_pdarray_by_name(f"{user_defined_name}.offsets")
+
+
+@typechecked
+def suffix_array(strings: Strings) -> SArrays:
+    """
+        Return the suffix arrays of given strings. The size/shape of each suffix
+    arrays is the same as the corresponding strings.
+    A simple example of suffix array is as follow. Given a string "banana$",
+    all the suffixes are as follows.
+    s[0]="banana$"
+    s[1]="anana$"
+    s[2]="nana$"
+    s[3]="ana$"
+    s[4]="na$"
+    s[5]="a$"
+    s[6]="$"
+    The suffix array of string "banana$"  is the array of indices of sorted suffixes.
+    s[6]="$"
+    s[5]="a$"
+    s[3]="ana$"
+    s[1]="anana$"
+    s[0]="banana$"
+    s[4]="na$"
+    s[2]="nana$"
+    so sa=[6,5,3,1,0,4,2]
+
+        Returns
+        -------
+        pdarray
+            The suffix arrays of the given strings
+
+        See Also
+        --------
+
+        Notes
+        -----
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error in executing group request or
+            creating the pdarray encapsulating the return message
+    """
+    cmd = "segmentedSuffixAry"
+    args = "{} {}".format(strings.objtype, strings.entry.name)
+    repMsg = generic_msg(cmd=cmd, args=args)
+    return SArrays(*(cast(str, repMsg).split("+")))
+
+
+@typechecked
+def lcp_array(suffixarrays: SArrays, strings: Strings) -> SArrays:
+    """
+        Return the longest common prefix of given suffix arrays. The size/shape of each lcp
+    arrays is the same as the corresponding suffix array.
+        -------
+        SArrays
+            The LCP arrays of the given suffix arrays
+
+        See Also
+        --------
+
+        Notes
+        -----
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error in executing group request or
+            creating the pdarray encapsulating the return message
+    """
+    cmd = "segmentedLCP"
+    args = "{} {} {} {}".format(
+        suffixarrays.objtype,
+        suffixarrays.offsets.name,
+        suffixarrays.bytes.name,
+        strings.entry.name,
+    )
+    repMsg = generic_msg(cmd=cmd, args=args)
+    return SArrays(*(cast(str, repMsg).split("+")))
+
+
+@typechecked
+def suffix_array_file(filename: str) -> tuple:
+    """
+        This function is major used for testing correctness and performance
+        Return the suffix array of given file name's content as a string.
+    A simple example of suffix array is as follow. Given string "banana$",
+    all the suffixes are as follows.
+    s[0]="banana$"
+    s[1]="anana$"
+    s[2]="nana$"
+    s[3]="ana$"
+    s[4]="na$"
+    s[5]="a$"
+    s[6]="$"
+    The suffix array of string "banana$"  is the array of indices of sorted suffixes.
+    s[6]="$"
+    s[5]="a$"
+    s[3]="ana$"
+    s[1]="anana$"
+    s[0]="banana$"
+    s[4]="na$"
+    s[2]="nana$"
+    so sa=[6,5,3,1,0,4,2]
+
+        Returns
+        -------
+        pdarray
+            The suffix arrays of the given strings
+
+        See Also
+        --------
+
+        Notes
+        -----
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error in executing group request or
+            creating the pdarray encapsulating the return message
+    """
+    cmd = "segmentedSAFile"
+    args = "{}".format(filename)
+    repMsg = generic_msg(cmd=cmd, args=args)
+    tmpmsg = cast(str, repMsg).split("+")
+    sastr = tmpmsg[0:2]
+    strstr = tmpmsg[2:4]
+    suffixarray = SArrays(*sastr)
+    originalstr = Strings(*strstr)
+    return suffixarray, originalstr

--- a/server/SegmentedSuffixArray.chpl
+++ b/server/SegmentedSuffixArray.chpl
@@ -1,0 +1,573 @@
+module SegmentedSuffixArray {
+  use MultiTypeSymbolTable;
+  use MultiTypeSymEntry;
+  use CommAggregation;
+  use SipHash;
+  use SegmentedArray;
+  use RadixSortLSD only radixSortLSD_ranks;
+  use Reflection;
+  use PrivateDist;
+  use ServerConfig;
+  use Time only Timer, getCurrentTime;
+  use Logging;
+  use ServerErrors;
+
+  private config const logLevel = ServerConfig.logLevel;
+  const saLogger = new Logger(logLevel);
+
+  private config param useHash = true;
+  param SegmentedArrayUseHash = useHash;
+
+  private config const in1dSortThreshold = 64;
+
+  /**
+   * Represents an array of arrays, implemented as a segmented array of integers.
+   * Instances are ephemeral, not stored in the symbol table. Instead, attributes
+   * of this class refer to symbol table entries that persist. This class is a
+   * convenience for bundling those persistent objects and defining suffix array-relevant
+   * operations.
+     Here we just copy SegString, we need change more in the future to fit suffix array
+   */
+  class SegSuffixArray {
+
+    /**
+     * The name of the SymEntry corresponding to the pdarray containing
+     * the offsets, which are start indices for each string bytearray
+     */
+    var offsetName: string;
+
+    /**
+     * The pdarray containing the offsets, which are the start indices of
+     * the bytearrays, each of whichs corresponds to an individual string.
+     */
+    var offsets: borrowed SymEntry(int);
+
+    /**
+     * The name of the SymEntry corresponding to the pdarray containing
+     * the string values where each value is byte array.
+     */
+    var valueName: string;
+
+    /**
+     * The pdaray containing the complete int array composed of integer index
+     * corresponding to each string,
+     */
+    var values: borrowed SymEntry(int);
+
+    /**
+     * The number of strings in the segmented array
+     */
+    var size: int;
+
+    /**
+     * The total number of bytes in the entire segmented array including
+     * the bytes corresonding to the strings as well as the nulls
+     * separating the string bytes.
+     */
+    var nBytes: int;
+
+    /*
+     * This version of the init method is the most common and is only used
+     * when the names of the segments (offsets) and values SymEntries are known.
+     */
+    proc init(segName: string, valName: string, st: borrowed SymTab) {
+      offsetName = segName;
+      // The try! is needed here because init cannot throw
+      var gs: borrowed GenSymEntry = try! getGenericTypedArrayEntry(segName, st);
+      // I want this to be borrowed, but that throws a lifetime error
+      var segs = toSymEntry(gs, int);
+      offsets = segs;
+      valueName = valName;
+
+      var vs: borrowed GenSymEntry = try! getGenericTypedArrayEntry(valName, st);
+      var vals = toSymEntry(vs, int);
+      values = vals;
+      size = segs.size;
+      nBytes = vals.size;
+    }
+
+    /*
+     * This version of init method takes segments and values arrays as
+     * inputs, generates the SymEntry objects for each and passes the
+     * offset and value SymTab lookup names to the alternate init method
+     */
+    proc init(segments: [] int, values: [] int, st: borrowed SymTab) {
+      var oName = st.nextName();
+      var segEntry = new shared SymEntry(segments);
+      try! st.addEntry(oName, segEntry);
+      var vName = st.nextName();
+      var valEntry = new shared SymEntry(values);
+      try! st.addEntry(vName, valEntry);
+      this.init(oName, vName, st);
+    }
+
+    proc show(n: int = 3) throws {
+      if (size >= 2*n) {
+        for i in 0..#n {
+            saLogger.info(getModuleName(),getRoutineName(),getLineNumber(),this[i]);
+        }
+        for i in size-n..#n {
+            saLogger.info(getModuleName(),getRoutineName(),getLineNumber(),this[i]);
+        }
+      } else {
+        for i in 0..#size {
+            saLogger.info(getModuleName(),getRoutineName(),getLineNumber(),this[i]);
+        }
+      }
+    }
+
+    /* Retrieve one string from the array */
+    proc this(idx: int): string throws {
+      if (idx < offsets.aD.low) || (idx > offsets.aD.high) {
+        throw new owned OutOfBoundsError();
+      }
+      // Start index of the string
+      var start = offsets.a[idx];
+      // Index of last (null) byte in string
+      var end: int;
+      if (idx == size - 1) {
+        end = nBytes - 1;
+      } else {
+        end = offsets.a[idx+1] - 1;
+      }
+      // Take the slice of the bytearray and "cast" it to a chpl string
+      var tmp=values.a[start..end];
+      var s: string;
+      var i: int;
+      s="";
+      for i in tmp do {
+        s = s + " " + i: string;
+      }
+      return s;
+    }
+
+    /* Take a slice of indices from the array. The slice must be a
+       Chapel range, i.e. low..high by stride, not a Python slice.
+       Returns arrays for the segment offsets and bytes of the slice.*/
+    proc this(const slice: range(stridable=true)) throws {
+      if (slice.low < offsets.aD.low) || (slice.high > offsets.aD.high) {
+          saLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
+          "Array is out of bounds");
+          throw new owned OutOfBoundsError();
+      }
+      // Early return for zero-length result
+      if (size == 0) || (slice.size == 0) {
+        return (makeDistArray(0, int), makeDistArray(0, int));
+      }
+      // Start of bytearray slice
+      var start = offsets.a[slice.low];
+      // End of bytearray slice
+      var end: int;
+      if (slice.high == offsets.aD.high) {
+        // if slice includes the last string, go to the end of values
+        end = values.aD.high;
+      } else {
+        end = offsets.a[slice.high+1] - 1;
+      }
+      // Segment offsets of the new slice
+      var newSegs = makeDistArray(slice.size, int);
+      ref oa = offsets.a;
+      forall (i, ns) in zip(newSegs.domain, newSegs) with (var agg = newSrcAggregator(int)) {
+        agg.copy(ns, oa[slice.low + i]);
+      }
+      // Offsets need to be re-zeroed
+      newSegs -= start;
+      var newVals = makeDistArray(end - start + 1, int);
+      ref va = values.a;
+      forall (i, nv) in zip(newVals.domain, newVals) with (var agg = newSrcAggregator(int)) {
+        agg.copy(nv, va[start + i]);
+      }
+      return (newSegs, newVals);
+    }
+
+    /* Gather strings by index. Returns arrays for the segment offsets
+       and bytes of the gathered strings.*/
+    proc this(iv: [?D] int) throws {
+      // Early return for zero-length result
+      if (D.size == 0) {
+        //return (makeDistArray(0, int), makeDistArray(0, uint(8)));
+        return (makeDistArray(0, int), makeDistArray(0, int));
+      }
+      // Check all indices within bounds
+      var ivMin = min reduce iv;
+      var ivMax = max reduce iv;
+      if (ivMin < 0) || (ivMax >= offsets.size) {
+          saLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
+                              "Array out of bounds");
+          throw new owned OutOfBoundsError();
+      }
+      saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                              "Computing lengths and offsets");
+      var t1 = getCurrentTime();
+      ref oa = offsets.a;
+      const low = offsets.aD.low, high = offsets.aD.high;
+      // Gather the right and left boundaries of the indexed strings
+      // NOTE: cannot compute lengths inside forall because agg.copy will
+      // experience race condition with loop-private variable
+      var right: [D] int, left: [D] int;
+      forall (r, l, idx) in zip(right, left, iv) with (var agg = newSrcAggregator(int)) {
+        if (idx == high) {
+          agg.copy(r, values.size);
+        } else {
+          agg.copy(r, oa[idx+1]);
+        }
+        agg.copy(l, oa[idx]);
+      }
+      // Lengths of segments including null bytes
+      var gatheredLengths: [D] int = right - left;
+      // The returned offsets are the 0-up cumulative lengths
+      var gatheredOffsets = (+ scan gatheredLengths);
+      // The total number of bytes in the gathered strings
+      var retBytes = gatheredOffsets[D.high];
+      gatheredOffsets -= gatheredLengths;
+
+      saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                "aggregation in %i seconds".format(getCurrentTime() - t1));
+      saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Copying values");
+      if logLevel == LogLevel.DEBUG {
+          t1 = getCurrentTime();
+      }
+      var gatheredVals = makeDistArray(retBytes, int);
+      // Multi-locale requires some extra localization work that is not needed
+      if CHPL_COMM != 'none' {
+        // Compute the src index for each byte in gatheredVals
+
+        /* For performance, we will do this with a scan, so first we need an array
+           with the difference in index between the current and previous byte. For
+           the interior of a segment, this is just one, but at the segment boundary,
+           it is the difference between the src offset of the current segment ("left")
+           and the src index of the last byte in the previous segment (right - 1).
+        */
+        var srcIdx = makeDistArray(retBytes, int);
+        srcIdx = 1;
+        var diffs: [D] int;
+        diffs[D.low] = left[D.low]; // first offset is not affected by scan
+        if (D.size > 1) {
+          // This expression breaks when D.size == 1, resulting in strange behavior
+          // However, this logic is only necessary when D.size > 1 anyway
+          diffs[D.interior(D.size-1)] = left[D.interior(D.size-1)] - (right[D.interior(-(D.size-1))] - 1);
+        }
+        // Set srcIdx to diffs at segment boundaries
+        forall (go, d) in zip(gatheredOffsets, diffs) with (var agg = newDstAggregator(int)) {
+          agg.copy(srcIdx[go], d);
+        }
+        srcIdx = + scan srcIdx;
+        // Now srcIdx has a dst-local copy of the source index and vals can be efficiently gathered
+        ref va = values.a;
+        forall (v, si) in zip(gatheredVals, srcIdx) with (var agg = newSrcAggregator(int)) {
+          agg.copy(v, va[si]);
+        }
+      } else {
+        ref va = values.a;
+        // Copy string data to gathered result
+        forall (go, gl, idx) in zip(gatheredOffsets, gatheredLengths, iv) {
+          for pos in 0..#gl {
+            gatheredVals[go+pos] = va[oa[idx]+pos];
+          }
+        }
+      }
+      saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                            "Gathered offsets and vals in %i seconds".format(
+                                           getCurrentTime() -t1));
+      return (gatheredOffsets, gatheredVals);
+    }
+
+    /* Logical indexing (compress) of strings. */
+    proc this(iv: [?D] bool) throws {
+      // Index vector must be same domain as array
+      if (D != offsets.aD) {
+          saLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
+                                                           "Array out of bounds");
+          throw new owned OutOfBoundsError();
+      }
+      saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
+                                                 "Computing lengths and offsets");
+      var t1 = getCurrentTime();
+      ref oa = offsets.a;
+      const low = offsets.aD.low, high = offsets.aD.high;
+      // Calculate the destination indices
+      var steps = + scan iv;
+      var newSize = steps[high];
+      steps -= iv;
+      // Early return for zero-length result
+      if (newSize == 0) {
+        return (makeDistArray(0, int), makeDistArray(0, int));
+      }
+      var segInds = makeDistArray(newSize, int);
+      forall (t, dst, idx) in zip(iv, steps, D) with (var agg = newDstAggregator(int)) {
+        if t {
+          agg.copy(segInds[dst], idx);
+        }
+      }
+      return this[segInds];
+    }
+
+    /* Apply a hash function to all strings. This is useful for grouping
+       and set membership. The hash used is SipHash128.*/
+    proc hash() throws {
+      // 128-bit hash values represented as 2-tuples of uint(64)
+      var hashes: [offsets.aD] 2*uint(64);
+      // Early exit for zero-length result
+      if (size == 0) {
+        return hashes;
+      }
+      ref oa = offsets.a;
+      ref va = values.a;
+      // Compute lengths of strings
+      var lengths = getLengths();
+      // Hash each string
+      // TO DO: test on clause with aggregator
+      forall (o, l, h) in zip(oa, lengths, hashes) {
+        const myRange = o..#l;
+        h = sipHash128(va, myRange);
+      }
+      return hashes;
+    }
+
+    /* Return a permutation that groups the strings. Because hashing is used,
+       this permutation will not sort the strings, but all equivalent strings
+       will fall in one contiguous block. */
+    proc argGroup() throws {
+      var t = new Timer();
+      if useHash {
+        // Hash all strings
+        saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Hashing strings");
+        if logLevel == LogLevel.DEBUG { t.start(); }
+        var hashes = this.hash();
+
+        if logLevel == LogLevel.DEBUG {
+            t.stop();
+            saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                           "hashing took %t seconds\nSorting hashes".format(t.elapsed()));
+            t.clear(); t.start();
+        }
+
+        // Return the permutation that sorts the hashes
+        var iv = radixSortLSD_ranks(hashes);
+        if logLevel == LogLevel.DEBUG { 
+            t.stop(); 
+            saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                            "sorting took %t seconds".format(t.elapsed()));
+        }
+        if logLevel == LogLevel.DEBUG {
+          var sortedHashes = [i in iv] hashes[i];
+          var diffs = sortedHashes[(iv.domain.low+1)..#(iv.size-1)] -
+                                                 sortedHashes[(iv.domain.low)..#(iv.size-1)];
+          printAry("diffs = ", diffs);
+          var nonDecreasing = [(d0,d1) in diffs] ((d0 > 0) || ((d0 == 0) && (d1 >= 0)));
+          saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                    "Are hashes sorted? %i".format(&& reduce nonDecreasing));
+        }
+        return iv;
+      } else {
+        var iv = argsort();
+        return iv;
+      }
+    }
+
+    /* Return lengths of all strings, including null terminator. */
+    proc getLengths() {
+      var lengths: [offsets.aD] int;
+      if (size == 0) {
+        return lengths;
+      }
+      ref oa = offsets.a;
+      const low = offsets.aD.low;
+      const high = offsets.aD.high;
+      forall (i, o, l) in zip(offsets.aD, oa, lengths) {
+        if (i == high) {
+          l = values.size - o;
+        } else {
+          l = oa[i+1] - o;
+        }
+      }
+      return lengths;
+    }
+
+    /* The comments above is treated as though they were ediff's comment string, which will cause sphinx errors
+     * It takes me several hours without any idea and thanks  Brad help out. He added the following
+     * line to solve the problem
+     * dummy chpldoc description for ediff()
+     */
+    proc ediff():[offsets.aD] int {
+      var diff: [offsets.aD] int;
+      if (size < 2) {
+        return diff;
+      }
+      ref oa = offsets.a;
+      ref va = values.a;
+      const high = offsets.aD.high;
+      forall (i, a) in zip(offsets.aD, diff) {
+        if (i < high) {
+          var asc: bool;
+          const left = oa[i]..oa[i+1]-1;
+          if (i < high - 1) {
+            const right = oa[i+1]..oa[i+2]-1;
+            a = -memcmp(va, left, va, right);
+          } else { // i == high - 1
+            const right = oa[i+1]..values.aD.high;
+            a = -memcmp(va, left, va, right);
+          }
+        } else { // i == high
+          a = 0;
+        }
+      }
+      return diff;
+    }
+
+    proc isSorted():bool {
+      if (size < 2) {
+        return true;
+      }
+      return (&& reduce (ediff() >= 0));
+    }
+
+    proc argsort(checkSorted:bool=false): [offsets.aD] int throws {
+      const ref D = offsets.aD;
+      const ref va = values.a;
+      if checkSorted && isSorted() {
+          saLogger.warn(getModuleName(),getRoutineName(),getLineNumber(),
+                                                   "argsort called on already sorted array");
+          var ranks: [D] int = [i in D] i;
+          return ranks;
+      }
+      var ranks = twoPhaseStringSort(this);
+      return ranks;
+    }
+
+  } // class SegSuffixArray
+
+
+
+  /* Test array of strings for membership in another array (set) of strings. Returns
+     a boolean vector the same size as the first array. */
+  proc in1d_Int(mainSar: SegSuffixArray, testSar: SegSuffixArray, invert=false) throws where useHash {
+    var truth: [mainSar.offsets.aD] bool;
+    // Early exit for zero-length result
+    if (mainSar.size == 0) {
+      return truth;
+    }
+    // Hash all suffix array for fast comparison
+    var t = new Timer();
+    saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Hashing strings");
+    if logLevel == LogLevel.DEBUG { t.start(); }
+    const hashes = mainSar.hash();
+    if logLevel == LogLevel.DEBUG {
+        t.stop();
+        saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                "%t seconds".format(t.elapsed()));
+        t.clear();
+        saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                           "Making associative domains for test set on each locale");
+        t.start();
+    }
+    // On each locale, make an associative domain with the hashes of the second array
+    // parSafe=false because we are adding in serial and it's faster
+    var localTestHashes: [PrivateSpace] domain(2*uint(64), parSafe=false);
+    coforall loc in Locales {
+      on loc {
+        // Local hashes of second array
+        ref mySet = localTestHashes[here.id];
+        mySet.requestCapacity(testSar.size);
+        const testHashes = testSar.hash();
+        for h in testHashes {
+          mySet += h;
+        }
+      }
+    }
+    if logLevel == LogLevel.DEBUG {
+      t.stop();
+      saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                             "%t seconds".format(t.elapsed()));
+      t.clear();
+      saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                             "Testing membership");
+      t.start();
+    }
+    [i in truth.domain] truth[i] = localTestHashes[here.id].contains(hashes[i]);
+    if logLevel == LogLevel.DEBUG {
+        t.stop();
+        saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                             "%t seconds".format(t.elapsed()));
+    }
+    return truth;
+  }
+
+
+  proc in1d_Int(mainSar: SegSuffixArray, testSar: SegSuffixArray, invert=false) throws where !useHash {
+    var truth: [mainSar.offsets.aD] bool;
+    // Early exit for zero-length result
+    if (mainSar.size == 0) {
+      return truth;
+    }
+    if (testSar.size <= in1dSortThreshold) {
+      for i in 0..#testSar.size {
+        truth |= (mainSar == testSar[i]);
+      }
+      return truth;
+    } else {
+      // This is inspired by numpy in1d
+      const (uoMain, uvMain, cMain, revIdx) = uniqueGroup(mainSar, returnInverse=true);
+      const (uoTest, uvTest, cTest, revTest) = uniqueGroup(testSar);
+      const (segs, vals) = concat(uoMain, uvMain, uoTest, uvTest);
+      saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+           "Unique strings in first array: %t\nUnique strings in second array: %t\nConcat length: %t".format(
+                                             uoMain.size, uoTest.size, segs.size));
+      var st = new owned SymTab();
+      const ar = new owned SegSuffixArray(segs, vals, st);
+      const order = ar.argsort();
+      const (sortedSegs, sortedVals) = ar[order];
+      const sar = new owned SegSuffixArray(sortedSegs, sortedVals, st);
+      if logLevel == LogLevel.DEBUG {
+          saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                            "Sorted concatenated unique strings:");
+          sar.show(10);
+          stdout.flush();
+      }
+      const D = sortedSegs.domain;
+      // First compare lengths and only check pairs whose lengths are equal (because gathering them is expensive)
+      var flag: [D] bool;
+      const lengths = sar.getLengths();
+      const ref saro = sar.offsets.a;
+      const ref sarv = sar.values.a;
+      const high = D.high;
+      forall (i, f, o, l) in zip(D, flag, saro, lengths) {
+        if (i < high) && (l == lengths[i+1]) {
+          const left = o..saro[i+1]-1;
+          var eq: bool;
+          if (i < high - 1) {
+            const right = saro[i+1]..saro[i+2]-1;
+            eq = (memcmp(sarv, left, sarv, right) == 0);
+          } else {
+            const ref right = saro[i+1]..sar.values.aD.high;
+            eq = (memcmp(sarv, left, sarv, right) == 0);
+          }
+          if eq {
+            f = true;
+            flag[i+1] = true;
+          }
+        }
+      }
+      saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                             "Flag pop: %t".format(+ reduce flag));
+
+      // Now flag contains true for both elements of duplicate pairs
+      if invert {flag = !flag;}
+      // Permute back to unique order
+      var ret: [D] bool;
+      forall (o, f) in zip(order, flag) with (var agg = newDstAggregator(bool)) {
+        agg.copy(ret[o], f);
+      }
+      if logLevel == LogLevel.DEBUG {
+          saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                "Ret pop: %t".format(+ reduce ret));
+      }
+      // Broadcast back to original (pre-unique) order
+      var truth: [mainSar.offsets.aD] bool;
+      forall (t, i) in zip(truth, revIdx) with (var agg = newSrcAggregator(bool)) {
+        agg.copy(t, ret[i]);
+      }
+      return truth;
+    }
+  }
+}

--- a/server/ServerModules.cfg
+++ b/server/ServerModules.cfg
@@ -3,3 +3,4 @@
 BFSMsg
 TriCntMsg
 TrussMsg
+SuffixArrayMsg

--- a/server/SuffixArrayConstruction.chpl
+++ b/server/SuffixArrayConstruction.chpl
@@ -1,0 +1,187 @@
+module SuffixArrayConstruction {
+  // This module contains algorithms to construct suffix arrays
+
+  //  Chapel implementation of the suffix array construction algorithm using skew algorithm from
+  // "Simple Linear Work Suffix Array Construction" by Juha Karkkainen and Peter Sanders (2003)
+  // Dec.7, 2020
+
+  /*
+  Returns a boolean indicating whether the pair (a1, a2) is less than or equal to pair (b1, b2)
+
+  :arg a1, a2, b1, b2: pairs to be compared
+  :type: int
+
+  :returns: boolean True iff pair (a1, a2) is less than or equal to pair (b1, b2)
+  */
+  inline proc leq_pairs(a1:int, a2:int, b1:int, b2:int): bool {
+    return (a1 < b1) || ((a1 == b1) && (a2 <= b2));  // lexicographic order for pairs
+  } 
+
+  /*
+  Returns a boolean indicating whether the triple (a1, a2, a3) is less than or equal to triple (b1, b2, b3)
+
+  :arg a1, a2, a3, b1, b2, b3: triples to be compared
+  :type: int
+
+  :returns: boolean True iff triple (a1, a2, a3) is less than or equal to pair (b1, b2, b3)
+  */
+  inline proc leq_triples(a1:int, a2:int, a3:int, b1:int, b2:int, b3:int): bool {
+    return (a1 < b1) || ((a1 == b1) && leq_pairs(a2, a3, b2, b3));  // lexicographic order for triples
+  }
+
+  /*
+  Using Radix Sort, stably sorts a[0..n-1] according to b[0..n-1] using keys 0..K from r[] 
+  Element a[i] is mapping to r[a[i]] where r is the alphabet with K+1 characters.
+
+  :arg a: array to be sorted
+  :type: [] int
+  :arg b: array used to sort
+  :type: [] int
+  :arg r: array containing keys
+  :type: [] int || uint(8)
+  :arg n: bound for indicies of a and b used during this calculation
+  :type: int
+  :arg K: number of keys
+  :type: int
+  */
+  proc radixPass(a:[] int, b:[] int, r:[] ?t, n:int, K:int) where t == int || t == uint(8) {
+    var c: [0..K] t = 0;
+
+    // count the number of occurences of each character in a
+    for i in a[0..#n] do c[r[i]] += 1;
+    // calculate the presum of c, so c[i] will be the starting position of different characters
+    c = (+ scan c) - c;
+    // let b[j] store the position of each a[i] based on their order.
+    // The same character but following the previous suffix will be put at the next position.
+    for i in a[0..#n] {
+      b[c[r[i]]] = i;
+      c[r[i]] += 1;
+    }
+  }
+
+  /*
+  Finds the suffix array SA of s[0..n-1] in {1..K}^n (n long with alphabet 1..K)
+  Pad out with 0s. Require s[n]=s[n+1]=s[n+2]=0, n>=2. So the size of s should be n+3
+
+  :arg s: n+3 long string to be converted into suffix array (where s[n]=s[n+1]=s[n+2]=0)
+  :type: [] int
+  :arg SA: Array to be populated with the suffix array for s
+  :type: [] int
+  :arg n: length of s (before padding out with 0s to n+2)
+  :type: int
+  :arg K: Size of alphabet
+  :type: int
+  */
+  proc SuffixArraySkew(s:[] int, SA:[] int, n:int, K:int) {
+    var n0 = (n+2)/3: int;
+    var n1 = (n+1)/3: int;
+    var n2 = n/3: int;
+    var n02 = n0 + n2: int;
+    var n12 = n1 + n2: int;
+    //number of elements meet i%3 = 0, 1, and 2.
+    //s[i] is the ith suffix, i in 0..n-1
+    var s12: [0..n02+2] int = 0;
+    // Here n02 instead of n12=n1+n2 is used for the later s0 building based on n1 elements
+    var SA12: [0..n02+2] int = 0;
+
+    var s0: [0..n0+2] int;
+    var SA0: [0..n0+2] int;
+    var j = 0: int;
+
+    // generate positions of mod 1 and mod 2 suffixes
+    // n0-n1 is used for building s0, s1 has the same number of elements as s0
+    for i in 0..n+(n0-n1)-1 {
+      if i%3 != 0 {
+        s12[j] = i;
+        j += 1;
+      }
+    }
+    // lsb radix sort the mod 1 and mod 2 triples
+    var tmps: [0..n+2] int;
+    forall i in 0..n-2 do tmps[i] = s[i+2];
+    radixPass(s12, SA12, tmps, n02, K);
+    forall i in 0..n-1 do tmps[i] = s[i+1];
+    radixPass(SA12, s12, tmps, n02, K);
+    radixPass(s12, SA12, s, n02, K);
+    // find lexicographic names of triples
+    var name = 0: int, c0 = -1: int, c1 = -1: int, c2 = -1: int;
+
+    for i in SA12[0..#n02] {
+      if s[i] != c0 || s[i+1] != c1 || s[i+2] != c2 {
+        name += 1;
+        c0 = s[i];
+        c1 = s[i+1];
+        c2 = s[i+2];
+      }
+      if i % 3 == 1 {
+        s12[i/3] = name; // mapping the suffix to small alphabets
+      } // left half
+      else {
+        s12[i/3 + n0] = name;
+      } // right half
+    }
+
+    // recurse if names are not unique
+    if name < n02 {
+      SuffixArraySkew(s12, SA12, n02, name);
+      // store unique names in s12 using the suffix array
+      for i in 0..#n02 do s12[SA12[i]] = i+1;
+      //restore the value of s12 since we will change its values during the procedure
+    }
+    else { // generate the suffix array of s12 directly
+      for i in 0..#n02 do SA12[s12[i]-1] = i;
+      // here SA12 is in fact the ISA array.
+    }
+    // stably sort the mod 0 suffixes from SA12 by their first character
+    j = 0;
+    for i in SA12[0..#n02] {
+      // here in fact we take advantage of the sorted SA12 to just sort s0 once to get its sorted array
+      // at first we think the postion i%3=1 is the position
+      if i < n0 {
+        s0[j] = 3*i;
+        j += 1;
+      }
+    }
+    radixPass(s0, SA0, s, n0, K);
+
+    // merge sorted SA0 suffixes and sorted SA12 suffixes
+    var p = 0: int; // first s0 position
+    var t = n0-n1: int; //first s1 position
+    var k = 0: int;
+    for tmpk in 0..#n {
+      proc GetI(): int {
+        return if SA12[t] < n0 then SA12[t] * 3 + 1 else (SA12[t]-n0) * 3 + 2;
+      }
+      var i = GetI(); // pos of current offset 12 suffix
+      j = SA0[p]; // pos of current offset 0 suffix
+      var flag: bool = if SA12[t] < n0 then leq_pairs(s[i], s12[SA12[t]+n0], s[j], s12[j/3]) else leq_triples(s[i], s[i+1], s12[SA12[t]-n0+1], s[j], s[j+1], s12[j/3+n0]);
+      if flag {
+        // suffix from SA12 is smaller
+        SA[k] = i;
+        k += 1;
+        t += 1;
+        if t == n02 {
+          // done --- only SA0 suffixes left
+          forall (i1,j1) in zip (k..n-1, p..#(n-k)) do SA[i1] = SA0[j1];
+          break;
+        }
+      }
+      else {
+        // suffix from SA0 is smaller
+        SA[k] = j;
+        k += 1;
+        p += 1;
+        var tmpt = t: int;
+        if p == n0 {
+          // done --- only SA12 suffixes left
+          for i1 in tmpt..n02-1 {
+            SA[k] = GetI();
+            t += 1;
+            k += 1;
+          }
+          break;
+        }
+      }
+    }
+  }
+}

--- a/server/SuffixArrayMsg.chpl
+++ b/server/SuffixArrayMsg.chpl
@@ -1,0 +1,667 @@
+module SuffixArrayMsg {
+  use Reflection;
+  use ServerErrors;
+  use Logging;
+  use Message;
+  use SegmentedArray;
+  use SegmentedSuffixArray only SegSuffixArray, in1d_Int;
+  use ServerErrorStrings;
+  use ServerConfig;
+  use MultiTypeSymbolTable;
+  use MultiTypeSymEntry;
+  use RandArray;
+  use IO;
+  use Map;
+
+  private config const logLevel = ServerConfig.logLevel;
+  const smLogger = new Logger(logLevel);
+  use SymArrayDmap;
+  use SuffixArrayConstruction;
+
+
+  /**
+   * Utility function to handle try/catch when trying to close objects.
+   */
+  proc closeFinally(c): bool {
+    var success = true;
+    try {
+        c.close();
+    } catch {
+        success = false;
+    }
+    return success;
+  }
+
+  /*
+    * Converts the JSON array to a integer pdarray
+  */
+  proc jsonToPdArrayInt(json: string, size: int) throws {
+      var f = opentmp(); defer { closeFinally(f); }
+      var w = f.writer();
+      w.write(json);
+      w.close();
+      var r = f.reader(start=0);
+      var array: [0..#size] int;
+      r.readf("%jt", array);
+      r.close();
+      f.close();
+      return array;
+  }
+
+  proc segmentLengthsIntMsg(cmd: string, payload: string, 
+                                          st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+    var (objtype, segName, valName) = payload.splitMsgToTuple(3);
+
+    // check to make sure symbols defined
+    st.checkTable(segName);
+    st.checkTable(valName);
+    
+    var rname = st.nextName();
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+            "cmd: %s objtype: %t segName: %t valName: %t".format(
+                   cmd,objtype,segName,valName));
+
+    select objtype {
+      when "int" {
+        var sarrays = new owned SegSuffixArray(segName, valName, st);
+        var lengths = st.addEntry(rname, sarrays.size, int);
+        // Do not include the null terminator in the length
+        lengths.a = sarrays.getLengths() - 1;
+      }
+      otherwise {
+          var errorMsg = notImplementedError(pn, "%s".format(objtype));
+          smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                      
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+      }
+    }
+
+    var repMsg = "created "+st.attrib(rname);
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
+  /*
+   * Assigns a segIntIndex, sliceIndex, or pdarrayIndex to the incoming payload
+   * consisting of a sub-command, object type, offset SymTab key, array SymTab
+   * key, and index value for the incoming payload.
+   * 
+   * Note: the sub-command indicates the index type which can be one of the following:
+   * 1. intIndex : setIntIndex
+   * 2. sliceIndex : segSliceIndex
+   * 3. pdarrayIndex : segPdarrayIndex
+  */ 
+  proc segmentedIntIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+    var repMsg: string;
+    // 'subcmd' is the type of indexing to perform
+    // 'objtype' is the type of segmented array
+    var (subcmd, objtype, rest) = payload.splitMsgToTuple(3);
+    var fields = rest.split();
+    var args: [1..#fields.size] string = fields; // parsed by subroutines
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                            "subcmd: %s objtype: %s rest: %s".format(subcmd,objtype,rest));
+    try {
+        select subcmd {
+            when "intIndex" {
+                return segIntIndex(objtype, args, st);
+            }
+            when "sliceIndex" {
+                return segSliceIndex(objtype, args, st);
+            }
+            when "pdarrayIndex" {
+                return segPdarrayIndex(objtype, args, st);
+            }
+            otherwise {
+                var errorMsg = "Error in %s, unknown subcommand %s".format(pn, subcmd);
+                smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);      
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+    } catch e: OutOfBoundsError {
+        var errorMsg = "index out of bounds";
+        smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);      
+        return new MsgTuple(errorMsg, MsgType.ERROR);
+    } catch e: Error {
+        var errorMsg = "unknown cause %t".format(e);
+        smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);      
+        return new MsgTuple(errorMsg, MsgType.ERROR);
+    }
+  }
+ 
+  /*
+    Returns the object corresponding to the index
+  */ 
+  proc segIntIndex(objtype: string, args: [] string, 
+                                         st: borrowed SymTab): MsgTuple throws {
+      var pn = Reflection.getRoutineName();
+
+      // check to make sure symbols defined
+      st.checkTable(args[1]);
+      st.checkTable(args[2]);
+      
+      select objtype {
+          when "int" {
+              // Make a temporary int array
+              var arrays = new owned SegSuffixArray(args[1], args[2], st);
+              // Parse the index
+              var idx = args[3]:int;
+              // TO DO: in the future, we will force the client to handle this
+              idx = convertPythonIndexToChapel(idx, arrays.size);
+              var s = arrays[idx];
+              var repMsg="item %s %jt".format("int", s);
+              smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          otherwise { 
+              var errorMsg = notImplementedError(pn, objtype); 
+              smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);      
+              return new MsgTuple(errorMsg, MsgType.ERROR);                          
+          }
+      }
+  }
+
+  /* Allow Python-style negative indices. */
+  proc convertPythonIndexToChapel(pyidx: int, high: int): int {
+    var chplIdx: int;
+    if (pyidx < 0) {
+      chplIdx = high + 1 + pyidx;
+    } else {
+      chplIdx = pyidx;
+    }
+    return chplIdx;
+  }
+
+  proc segSliceIndex(objtype: string, args: [] string, 
+                                         st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+
+    // check to make sure symbols defined
+    st.checkTable(args[1]);
+    st.checkTable(args[2]);
+
+    select objtype {
+      when "int" {
+            // Make a temporary integer  array
+            var sarrays = new owned SegSuffixArray(args[1], args[2], st);
+            // Parse the slice parameters
+            var start = args[3]:int;
+            var stop = args[4]:int;
+            var stride = args[5]:int;
+            // Only stride-1 slices are allowed for now
+            if (stride != 1) {
+                var errorMsg = notImplementedError(pn, "stride != 1");
+                smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+            // TO DO: in the future, we will force the client to handle this
+            var slice: range(stridable=true) = convertPythonSliceToChapel(start, stop, stride);
+            var newSegName = st.nextName();
+            var newValName = st.nextName();
+            // Compute the slice
+            var (newSegs, newVals) = sarrays[slice];
+            // Store the resulting offsets and bytes arrays
+            var newSegsEntry = new shared SymEntry(newSegs);
+            var newValsEntry = new shared SymEntry(newVals);
+            st.addEntry(newSegName, newSegsEntry);
+            st.addEntry(newValName, newValsEntry);
+        
+            var repMsg = "created " + st.attrib(newSegName) + " +created " + st.attrib(newValName);
+            smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+        }
+        otherwise {
+            var errorMsg = notImplementedError(pn, objtype);
+            smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);      
+            return new MsgTuple(errorMsg, MsgType.ERROR);          
+        }
+    }
+  }
+
+  proc convertPythonSliceToChapel(start:int, stop:int, stride:int=1): range(stridable=true) {
+    var slice: range(stridable=true);
+    // convert python slice to chapel slice
+    // backwards iteration with negative stride
+    if  (start > stop) & (stride < 0) {slice = (stop+1)..start by stride;}
+    // forward iteration with positive stride
+    else if (start <= stop) & (stride > 0) {slice = start..(stop-1) by stride;}
+    // BAD FORM start < stop and stride is negative
+    else {slice = 1..0;}
+    return slice;
+  }
+
+  proc segPdarrayIndex(objtype: string, args: [] string, 
+                                 st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+
+    // check to make sure symbols defined
+    st.checkTable(args[1]);
+    st.checkTable(args[2]);
+
+    var newSegName = st.nextName();
+    var newValName = st.nextName();
+    
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                  "objtype:%s".format(objtype));
+    
+    select objtype {
+        when "int" {
+            var sarrays = new owned SegSuffixArray(args[1], args[2], st);
+            var iname = args[3];
+            var gIV: borrowed GenSymEntry = getGenericTypedArrayEntry(iname, st);
+            try {
+                select gIV.dtype {
+                    when DType.Int64 {
+                        var iv = toSymEntry(gIV, int);
+                        var (newSegs, newVals) = sarrays[iv.a];
+                        var newSegsEntry = new shared SymEntry(newSegs);
+                        var newValsEntry = new shared SymEntry(newVals);
+                        st.addEntry(newSegName, newSegsEntry);
+                        st.addEntry(newValName, newValsEntry);
+                    }
+                    when DType.Bool {
+                        var iv = toSymEntry(gIV, bool);
+                        var (newSegs, newVals) = sarrays[iv.a];
+                        var newSegsEntry = new shared SymEntry(newSegs);
+                        var newValsEntry = new shared SymEntry(newVals);
+                        st.addEntry(newSegName, newSegsEntry);
+                        st.addEntry(newValName, newValsEntry);
+                    }
+                    otherwise {
+                        var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
+                        smLogger.error(getModuleName(),getRoutineName(),
+                                                      getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
+            catch e: Error {
+                var errorMsg= "Error: %t".format(e.message());
+                smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
+                      e.message());
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+        otherwise {
+            var errorMsg = "unsupported objtype: %t".format(objtype);
+            smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(notImplementedError(pn, objtype), MsgType.ERROR);
+        }
+    }
+    var repMsg = "created " + st.attrib(newSegName) + "+created " + st.attrib(newValName);
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
+  proc segBinopvvIntMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+    var repMsg: string;
+    var (op,
+         // Type and attrib names of left segmented array
+         ltype, lsegName, lvalName,
+         // Type and attrib names of right segmented array
+         rtype, rsegName, rvalName, leftStr, jsonStr)
+           = payload.splitMsgToTuple(9);
+
+    // check to make sure symbols defined
+    st.checkTable(lsegName);
+    st.checkTable(lvalName);
+    st.checkTable(rsegName);
+    st.checkTable(rvalName);
+
+    select (ltype, rtype) {
+        when ("int", "int") {
+          var lsa = new owned SegSuffixArray(lsegName, lvalName, st);
+          var rsa = new owned SegSuffixArray(rsegName, rvalName, st);
+          select op {
+            when "==" {
+              var rname = st.nextName();
+              var e = st.addEntry(rname, lsa.size, bool);
+              e.a = (lsa == rsa);
+              repMsg = "created " + st.attrib(rname);
+            }
+            when "!=" {
+              var rname = st.nextName();
+              var e = st.addEntry(rname, lsa.size, bool);
+              e.a = (lsa != rsa);
+              repMsg = "created " + st.attrib(rname);
+            }
+            otherwise {
+              var errorMsg= notImplementedError(pn, ltype, op, rtype);
+              smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+          }
+        }
+        otherwise {
+          var errorMsg= unrecognizedTypeError(pn, "("+ltype+", "+rtype+")");
+          smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+    }
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
+  proc segBinopvsIntMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+    var repMsg: string;
+    var (op, objtype, segName, valName, valtype, encodedVal)  = payload.splitMsgToTuple(6);
+
+    // check to make sure symbols defined
+    st.checkTable(segName);
+    st.checkTable(valName);
+    var json = jsonToPdArrayInt(encodedVal, 1);
+    var value = json[json.domain.low];
+    var rname = st.nextName();
+    select (objtype, valtype) {
+      when ("int", "int") {
+        var sarrays  = new owned SegSuffixArray(segName, valName, st);
+        select op {
+          when "==" {
+            var e = st.addEntry(rname, sarrays.size, bool);
+            var tmp=sarrays[sarrays.offsets.aD.low]:int;
+            e.a = (tmp == value);
+          }
+          when "!=" {
+            var e = st.addEntry(rname, sarrays.size, bool);
+            var tmp=sarrays[sarrays.offsets.aD.low]:int;
+            e.a = (tmp != value);
+          }
+          otherwise {
+            var errorMsg= notImplementedError(pn, objtype, op, valtype);
+            smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      }
+      otherwise {
+          var errorMsg= unrecognizedTypeError(pn, "("+objtype+", "+valtype+")");
+          smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+      }
+    }
+    repMsg= "created " + st.attrib(rname);
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
+  proc segIn1dIntMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+    var repMsg: string;
+    var (mainObjtype, mainSegName, mainValName, testObjtype, testSegName,
+         testValName, invertStr) = payload.splitMsgToTuple(7);
+
+    // check to make sure symbols defined
+    st.checkTable(mainSegName);
+    st.checkTable(mainValName);
+    st.checkTable(testSegName);
+    st.checkTable(testValName);
+
+    var invert: bool;
+    if invertStr == "True" {invert = true;}
+    else if invertStr == "False" {invert = false;}
+    else {
+          var errorMsg="Error: Invalid argument in %s: %s (expected True or False)".format(pn, invertStr);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+    }
+    var rname = st.nextName();
+    select (mainObjtype, testObjtype) {
+    when ("int", "int") {
+      var mainSA = new owned SegSuffixArray(mainSegName, mainValName, st);
+      var testSA = new owned SegSuffixArray(testSegName, testValName, st);
+      var e = st.addEntry(rname, mainSA.size, bool);
+      if invert {
+        e.a = !in1d_Int(mainSA, testSA);
+      }
+      else {
+        e.a = in1d_Int(mainSA, testSA);
+      }
+    }
+    otherwise {
+        var errorMsg = unrecognizedTypeError(pn, "("+mainObjtype+", "+testObjtype+")");
+        smLogger.error(getModuleName(), getRoutineName(), getLineNumber(), errorMsg);
+        return new MsgTuple(errorMsg, MsgType.ERROR);
+      }
+    }
+    repMsg = "created " + st.attrib(rname);
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
+  proc segSuffixArrayMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+      var pn = Reflection.getRoutineName();
+      var (objtype, entryName) = payload.splitMsgToTuple(2);
+      var repMsg: string;
+
+      //var strings = new owned SegString(segName, valName, st);
+      var strings = getSegString(entryName, st);
+      var size=strings.size;
+      var nBytes = strings.nBytes;
+      var length=strings.getLengths();
+      var offsegs = (+ scan length) - length;
+      select (objtype) {
+          when "str" {
+              // To be checked, I am not sure if this formula can estimate the total memory requirement
+              // Lengths + 2*segs + 2*vals (copied to SymTab)
+              overMemLimit(8*size + 16*size + nBytes);
+
+              //allocate an offset array
+              var sasoff = offsegs;
+              //allocate an values array
+              var sasval:[0..(nBytes-1)] int;
+              // var lcpval:[0..(nBytes-1)] int; now we will not build the LCP array at the same time
+
+              var i:int;
+              var j:int;
+              forall i in 0..(size-1) do {
+              // the start position of ith string in value array
+
+                var startposition:int;
+                var endposition:int;
+                startposition = offsegs[i];
+                endposition = startposition+length[i]-1;
+                // what we do in the select structure is filling the sasval array with correct index
+                var sasize=length[i]:int;
+                ref strArray=strings.values.a[startposition..endposition];
+                var tmparray:[0..sasize+2] int;
+                var intstrArray:[0..sasize+2] int;
+                var x:int;
+                var y:int;
+                forall (x,y) in zip ( intstrArray[0..sasize-1],
+                    strings.values.a[startposition..endposition]) do x=y;
+                intstrArray[sasize]=0;
+                intstrArray[sasize+1]=0;
+                intstrArray[sasize+2]=0;
+                SuffixArraySkew(intstrArray,tmparray,sasize,256);
+                for (x, y) in zip(sasval[startposition..endposition], tmparray[0..sasize-1]) do
+                    x = y;
+              }
+              var segName2 = st.nextName();
+              var valName2 = st.nextName();
+
+              var segEntry = new shared SymEntry(sasoff);
+              var valEntry = new shared SymEntry(sasval);
+              st.addEntry(segName2, segEntry);
+              st.addEntry(valName2, valEntry);
+              repMsg = 'created ' + st.attrib(segName2) + '+created ' + st.attrib(valName2);
+              smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          otherwise {
+              var errorMsg = notImplementedError(pn, "("+objtype+")");
+              smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+      }
+  }
+
+  proc segLCPMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+      var pn = Reflection.getRoutineName();
+      var (objtype, segName, valName, entryName) = payload.splitMsgToTuple(4);
+      var repMsg: string;
+
+      // check to make sure symbols defined
+      st.checkTable(segName);
+      st.checkTable(valName);
+
+      var suffixarrays = new owned SegSuffixArray(segName, valName, st);
+      var size=suffixarrays.size;
+      var nBytes = suffixarrays.nBytes;
+      var length=suffixarrays.getLengths();
+      var offsegs = (+ scan length) - length;
+      var strings = getSegString(entryName, st);
+
+      select (objtype) {
+          when "int" {
+              // To be checked, I am not sure if this formula can estimate the total memory requirement
+              // Lengths + 2*segs + 2*vals (copied to SymTab)
+              overMemLimit(8*size + 16*size + nBytes);
+
+              //allocate an offset array
+              var sasoff = offsegs;
+              //allocate an values array
+              var lcpval:[0..(nBytes-1)] int;
+
+              var i:int;
+              var j:int;
+              forall i in 0..(size-1) do {
+                // the start position of ith surrix array  in value array
+                var startposition:int;
+                var endposition:int;
+                startposition = offsegs[i];
+                endposition = startposition+length[i]-1;
+
+                var sasize=length[i]:int;
+                ref sufArray=suffixarrays.values.a[startposition..endposition];
+                ref strArray=strings.values.a[startposition..endposition];
+                // Here we calculate the lcp(Longest Common Prefix) array value
+                forall j in startposition+1..endposition do{
+                        var tmpcount=0:int;
+                        var tmpbefore=sufArray[j-1]:int;
+                        var tmpcur=sufArray[j]:int;
+                        var tmplen=min(sasize-tmpcur, sasize-tmpbefore);
+                        var tmpi:int;
+                        for tmpi in 0..tmplen-1 do {
+                            if (strArray[tmpbefore]!=strArray[tmpcur]) {
+                                 break;
+                            }
+                            tmpbefore+=1;
+                            tmpcur+=1;
+                            tmpcount+=1;
+                        }
+                        lcpval[j]=tmpcount;
+                }
+              }
+              var lcpsegName = st.nextName();
+              var lcpvalName = st.nextName();
+
+              var lcpsegEntry = new shared SymEntry(sasoff);
+              var lcpvalEntry = new shared SymEntry(lcpval);
+              st.addEntry(lcpsegName, lcpsegEntry);
+              st.addEntry(lcpvalName, lcpvalEntry);
+              repMsg = 'created ' + st.attrib(lcpsegName) + '+created ' + st.attrib(lcpvalName);
+              smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          otherwise {
+              var errorMsg = notImplementedError(pn, "("+objtype+")");
+              smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+      }
+
+  }
+
+  proc segSAFileMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+      // directly read a string from given file and generate its suffix array
+      var pn = Reflection.getRoutineName();
+      var FileName = payload;
+      var repMsg: string;
+
+      var filesize:int;
+      var f = open(FileName, iomode.r);
+      var size=1:int;
+      var nBytes = f.size;
+      var length:[0..0] int  =nBytes;
+      var offsegs:[0..0] int =0 ;
+
+      var sasize=nBytes:int;
+      var startposition:int;
+      var endposition:int;
+      startposition = 0;
+      endposition = nBytes-1;
+      var strArray:[startposition..endposition]uint(8);
+      var r = f.reader(kind=ionative);
+      r.read(strArray);
+      r.close();
+
+      var segName = st.nextName();
+      var valName = st.nextName();
+
+      var segEntry = new shared SymEntry(offsegs);
+      var valEntry = new shared SymEntry(strArray);
+      st.addEntry(segName, segEntry);
+      st.addEntry(valName, valEntry);
+
+      select ("str") {
+          when "str" {
+              // To be checked, I am not sure if this formula can estimate the total memory requirement
+              // Lengths + 2*segs + 2*vals (copied to SymTab)
+              overMemLimit(8*size + 16*size + nBytes);
+
+              //allocate an offset array
+              var sasoff = offsegs;
+              //allocate a suffix array  values array and lcp array
+              var sasval:[0..(nBytes-1)] int;
+              //var lcpval:[0..(nBytes-1)] int;
+
+              var i:int;
+              forall i in 0..(size-1) do {
+              // the start position of ith string in value array
+                var sasize=length[i]:int;
+                var tmparray:[0..sasize+2] int;
+                var intstrArray:[0..sasize+2] int;
+                var x:int;
+                var y:int;
+                forall (x,y) in zip ( intstrArray[0..sasize-1],strArray[startposition..endposition]) do x=y;
+                intstrArray[sasize]=0;
+                intstrArray[sasize+1]=0;
+                intstrArray[sasize+2]=0;
+                SuffixArraySkew(intstrArray,tmparray,sasize,256);
+                for (x, y) in zip(sasval[startposition..endposition], tmparray[0..sasize-1]) do
+                   x = y; 
+              } // end of forall
+              var segName2 = st.nextName();
+              var valName2 = st.nextName();
+
+              var segEntry = new shared SymEntry(sasoff);
+              var valEntry = new shared SymEntry(sasval);
+              st.addEntry(segName2, segEntry);
+              st.addEntry(valName2, valEntry);
+              repMsg = 'created ' + st.attrib(segName2) + '+created ' + st.attrib(valName2)
+                        + '+created ' + st.attrib(segName) + '+created ' + st.attrib(valName);
+              smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          otherwise {
+              var errorMsg = notImplementedError(pn, "("+FileName+")");
+              smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+      }
+  }
+
+  proc registerMe() {
+    use CommandMap;
+    registerFunction("segmentIntLengths", segmentLengthsIntMsg, getModuleName());
+    registerFunction("segmentedIntIndex", segmentedIntIndexMsg, getModuleName());
+    registerFunction("segmentedBinopvvInt", segBinopvvIntMsg, getModuleName());
+    registerFunction("segmentedBinopvsInt", segBinopvsIntMsg, getModuleName());
+    registerFunction("segmentedIn1dInt", segIn1dIntMsg, getModuleName());
+    registerFunction("segmentedSuffixAry", segSuffixArrayMsg, getModuleName());
+    registerFunction("segmentedLCP", segLCPMsg, getModuleName());
+    registerFunction("segmentedSAFile", segSAFileMsg, getModuleName());
+  }
+}

--- a/server/UnitTestSuffixArrayConstruction.chpl
+++ b/server/UnitTestSuffixArrayConstruction.chpl
@@ -1,0 +1,37 @@
+// use TestBase;
+// use SuffixArrayConstruction;
+
+
+// proc testSuffixArraySkew(byteString: bytes, expectedSuffixArray: [] int) throws {
+//   var byteArray = byteString.bytes();
+//   var d: Diags;
+//   var size: int = byteArray.size;
+
+//   // Follows segSuffixArrayMsg in SegmentedMsg.chpl including padding with 0s 
+//   var integerArray: [0..size+2] int;
+//   var tmpArray: [0..size+2] int;
+//   var suffixArray: [0..size-1] int;
+
+//   var x:int;
+//   var y:int;
+//   forall (x, y) in zip(integerArray[0..size-1], byteArray[0..size-1]) do x=y;
+//   integerArray[size]=0;
+//   integerArray[size+1]=0;
+//   integerArray[size+2]=0;
+
+//   writeln(">>> SuffixArrayConstruction for %s".format(byteString.decode().strip('\x00'))); stdout.flush();
+//   d.start();
+//   SuffixArraySkew(integerArray, tmpArray, size, 256);
+//   d.stop("SuffixArrayConstruction");
+//   for (x, y) in zip(suffixArray[0..size-1], tmpArray[0..size-1])  do x = y;
+//   writeln("Expected:\n%t".format(expectedSuffixArray));
+//   writeln("Actual:\n%t".format(suffixArray));
+// }
+
+// proc main() {
+//   // "yabbadabbado" follows the example in Section 3 from "Linear Work Suffix Array Construction"
+//   try! testSuffixArraySkew(b"yabbadabbado\x00", [12, 1, 6, 4, 9, 3, 8, 2, 7, 5, 10, 11, 0]);
+
+//   // "banana" follows the example in the docstring of suffix_array on the client-side
+//   try! testSuffixArraySkew(b"banana\x00", [6, 5, 3, 1, 0, 4, 2]);
+// }

--- a/server/UnitTestSuffixArrayConstruction.good
+++ b/server/UnitTestSuffixArrayConstruction.good
@@ -1,0 +1,10 @@
+>>> SuffixArrayConstruction for yabbadabbado
+Expected:
+12 1 6 4 9 3 8 2 7 5 10 11 0
+Actual:
+12 1 6 4 9 3 8 2 7 5 10 11 0
+>>> SuffixArrayConstruction for banana
+Expected:
+6 5 3 1 0 4 2
+Actual:
+6 5 3 1 0 4 2


### PR DESCRIPTION
My first pass at bringing the suffix array functionality into `arkouda-njit`

I have compiled with this functionality using `$ python server-config.py --arkouda=$HOME/proj/arkouda | bash`. But haven't figured out a way to test the suffix-array functionality yet. I'm putting this up as a draft request to get some preliminary thoughts.

Major changes other than relocating functions are:
- renaming `SegmentedMsg` to `SuffixArrayMsg` to not conflict with main repo and renaming the functions within to include `Int` (following the example of other functions in suffix array). The strings functionality was removed from these functions
- Updates to locations where `.lookup` was called. This has been replaced with `getGenericTypedArrayEntry`
- Updates to locations referencing segstrings as 2 parts (bytes and values) instead of one composite entry
- The siphash code from the original PR is not included because I *think* SipHash is able to handle it. I might be wrong about that and need to figure out a way to add that in

This functionality is being transferred from PR #[865](https://github.com/Bears-R-Us/arkouda/pull/865) in the main arkouda repo
and tracked in Issue #[1173](https://github.com/Bears-R-Us/arkouda/issues/1173) in the main repo