### PR TITLE
changed storing list of strings to list of tuples of strings

### DIFF
--- a/arachne/arachne_simple_tests.py
+++ b/arachne/arachne_simple_tests.py
@@ -72,7 +72,5 @@ if __name__ == "__main__":
     graph.add_edge_properties(owns_edge_properties)
     print("Successfully added owns edge properties.")
 
-    print(f"DEGREE VIEW OF GRAPH {graph.degree()}")
-
     ak.shutdown()
 

--- a/arachne/server/GraphMsg.chpl
+++ b/arachne/server/GraphMsg.chpl
@@ -1551,9 +1551,9 @@ module GraphMsg {
         var graph = gEntry.graph;
         
         var node_map = toSymEntry(graph.getComp("NODE_MAP"), int).a;
-        var node_props: [node_map.domain] list(string, parSafe=true);
+        var node_props: [node_map.domain] list((string,string), parSafe=true);
         if graph.hasComp("NODE_PROPS") {
-            node_props = toSymEntry(graph.getComp("NODE_PROPS"), list(string, parSafe=true)).a;
+            node_props = toSymEntry(graph.getComp("NODE_PROPS"), list((string,string), parSafe=true)).a;
         }
 
         var node_map_r = toSymEntryAD(graph.getComp("NODE_MAP_R")).a;
@@ -1562,7 +1562,7 @@ module GraphMsg {
         forall i in 1..arrays_list.size - 1 {
             var curr_prop_arr:SegString = getSegString(arrays_list[i], st);
             forall j in nodes_arr.domain {
-                node_props[node_map_r[nodes_arr[j]]].append(cols_list[i] + " : " + curr_prop_arr[j]);
+                node_props[node_map_r[nodes_arr[j]]].append((cols_list[i],curr_prop_arr[j]));
             }   
         }
         // Add the component for the node labels for the graph. 
@@ -1622,9 +1622,9 @@ module GraphMsg {
         var dst_actual = toSymEntry(graph.getComp("DST"), int).a;
 
         // Create array of lists to store edge_props and populate it. 
-        var edge_props: [src_actual.domain] list(string, parSafe=true);
+        var edge_props: [src_actual.domain] list((string,string), parSafe=true);
         if(graph.hasComp("EDGE_PROPS")) {
-            edge_props = toSymEntry(graph.getComp("EDGE_PROPS"), list(string, parSafe=true)).a;
+            edge_props = toSymEntry(graph.getComp("EDGE_PROPS"), list((string,string), parSafe=true)).a;
         }
 
         forall x in 2..arrays_list.size - 1 {
@@ -1639,7 +1639,7 @@ module GraphMsg {
                 var neighborhood = dst_actual[start..end-1];
                 var ind = bin_search_v(neighborhood, neighborhood.domain.lowBound, neighborhood.domain.highBound, v);
 
-                edge_props[ind].append(cols_list[x] + " : " + curr_prop_arr[i]); // or j
+                edge_props[ind].append((cols_list[x],curr_prop_arr[i])); // or j
             }
         }
         
@@ -1648,6 +1648,8 @@ module GraphMsg {
         timer.stop();
         var repMsg = "edge properties added";
         outMsg = "Adding edge properties to property graph takes " + timer.elapsed():string;
+
+        print_graph_serverside(graph);
         
         // Print out debug information to arkouda server output. 
         smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),outMsg);

--- a/arachne/server/Utils.chpl
+++ b/arachne/server/Utils.chpl
@@ -33,8 +33,12 @@ module Utils {
             var curr_comp = comp:string;
             if G.hasComp(curr_comp) {
                 select curr_comp {
-                    when "RELATIONSHIPS", "NODE_LABELS", "NODE_PROPS", "EDGE_PROPS" {
+                    when "RELATIONSHIPS", "NODE_LABELS" {
                         var X = toSymEntry(G.getComp(comp:string), list(string, parSafe=true)).a;
+                        writeln(comp:string, " = ", X);
+                    }
+                    when "NODE_PROPS", "EDGE_PROPS" {
+                        var X = toSymEntry(G.getComp(comp:string), list((string,string), parSafe=true)).a;
                         writeln(comp:string, " = ", X);
                     }
                     when "EDGE_WEIGHT", "EDGE_WEIGHT_R" {


### PR DESCRIPTION
The storage for properties used to be as a string delimited by a colon as such: "property_name : property_value" this was updated in Chapel to be a tuple instead as such: (property_name:string, property_value:string) this way we can extract property_name and property_value without first splitting the string. 

Further, in Utils.chpl we updated the print_graph_serverside() function to handle the new updated data structure for node and edge properties. 