### PR TITLE
ensure compatibiltiy with 1.32.0

### DIFF
--- a/arachne/server/PropertyGraphMsg.chpl
+++ b/arachne/server/PropertyGraphMsg.chpl
@@ -172,7 +172,7 @@ module DipSLLPropertyGraphMsg {
         // Get graph for usage and the node label mapper. 
         var gEntry: borrowed GraphSymEntry = getGraphSymEntry(graphEntryName, st); 
         var graph = gEntry.graph;
-        var label_mapper_entry = toSegStringSymEntry(graph.getComp("VERTEX_LABELS_MAP"));
+        const ref label_mapper_entry = toSegStringSymEntry(graph.getComp("VERTEX_LABELS_MAP"));
 
         // Add new copies of each to the symbol table.
         var label_mapper = assembleSegStringFromParts(label_mapper_entry.offsetsEntry, label_mapper_entry.bytesEntry, st);
@@ -197,7 +197,7 @@ module DipSLLPropertyGraphMsg {
         // Get graph for usage and the edge relationship mapper. 
         var gEntry: borrowed GraphSymEntry = getGraphSymEntry(graphEntryName, st); 
         var graph = gEntry.graph;
-        var relationship_mapper_entry = toSegStringSymEntry(graph.getComp("EDGE_RELATIONSHIPS_MAP"));
+        const ref relationship_mapper_entry = toSegStringSymEntry(graph.getComp("EDGE_RELATIONSHIPS_MAP"));
 
         // Add new copies of each to the symbol table.
         var relationship_mapper = assembleSegStringFromParts(relationship_mapper_entry.offsetsEntry, relationship_mapper_entry.bytesEntry, st);

--- a/arachne/server/TrussMsg.chpl
+++ b/arachne/server/TrussMsg.chpl
@@ -688,7 +688,7 @@ module TrussMsg {
 
       proc BatchMaxTrussMinSearch(kvalue:int,nei:[?D1] int, start_i:[?D2] int,src:[?D3] int, dst:[?D4] int,
                         neiR:[?D11] int, start_iR:[?D12] int,srcR:[?D13] int, dstR:[?D14] int,
-                        TriCount:[?D5] atomic int, EdgeDeleted:[?D6] int ):int{ 
+                        TriCount:[?D5] atomic int, EdgeDeleted:[?D6] int ):int throws{ 
 
 
           var SetCurF=  new DistBag(int,Locales);//use bag to keep the current frontier


### PR DESCRIPTION
Made some changes to ensure compatibility with Chapel 1.32.0.

Main changes:
Added to Truss function a `throws`.
When getting `SegStringSymEntry` from `GraphArray` `enum` you must use `const ref` instead of `var` due to Chapel 1.32.0 changes in scoped variables. 