### PR TITLE
ADDED reversed arrays for directed graphs to find in-neighbors in constant time

### DIFF
--- a/arachne/server/BuildGraphMsg.chpl
+++ b/arachne/server/BuildGraphMsg.chpl
@@ -47,8 +47,8 @@ module BuildGraphMsg {
         // Parse the message from the Python front-end.
         var akarray_srcS = msgArgs.getValueOf("AkArraySrc");
         var akarray_dstS = msgArgs.getValueOf("AkArrayDst");
-        var akarray_vmapS = msgArgs.getValueOf("AkArrayVmap");
         var akarray_segS = msgArgs.getValueOf("AkArraySeg");
+        var akarray_vmapS = msgArgs.getValueOf("AkArrayVmap");
         var akarray_weightS = msgArgs.getValueOf("AkArrayWeight");
         var weightedS = msgArgs.getValueOf("Weighted");
         var directedS = msgArgs.getValueOf("Directed");
@@ -134,6 +134,30 @@ module BuildGraphMsg {
                     return new MsgTuple(errorMsg, MsgType.ERROR);
                 }
             }
+        }
+
+        var akarray_srcRS, akarray_dstRS, akarray_segRS:string;
+        if directed {
+            akarray_srcRS = msgArgs.getValueOf("AkArraySrcR");
+            akarray_dstRS = msgArgs.getValueOf("AkArrayDstR");
+            akarray_segRS = msgArgs.getValueOf("AkArraySegR");
+
+            var akarray_srcR_entry: borrowed GenSymEntry = getGenericTypedArrayEntry(akarray_srcRS, st);
+            var akarray_dstR_entry: borrowed GenSymEntry = getGenericTypedArrayEntry(akarray_dstRS, st);
+            var akarray_segR_entry: borrowed GenSymEntry = getGenericTypedArrayEntry(akarray_segRS, st);
+
+            var akarray_srcR_sym = toSymEntry(akarray_srcR_entry,int);
+            var srcR = akarray_srcR_sym.a;
+
+            var akarray_dstR_sym = toSymEntry(akarray_dstR_entry,int);
+            var dstR = akarray_dstR_sym.a;
+
+            var akarray_segR_sym = toSymEntry(akarray_segR_entry, int);
+            var segmentsR = akarray_segR_sym.a;
+
+            graph.withComp(new shared SymEntry(srcR):GenSymEntry, "SRC_R")
+                .withComp(new shared SymEntry(dstR):GenSymEntry, "DST_R")
+                .withComp(new shared SymEntry(segmentsR):GenSymEntry, "SEGMENTS_R");
         }
 
         // Create the ranges array that keeps track of the vertices the edge arrays store on each

--- a/arachne/server/GraphArray.chpl
+++ b/arachne/server/GraphArray.chpl
@@ -34,6 +34,11 @@ module GraphArray {
         EDGE_PROPS_DTYPE_MAP,   // Sorted array of column datatype to integer id (array index)
         EDGE_PROPS_COL2DTYPE,   // Map of column names to the datatype of the column
 
+        // For directed graphs we also want to maintain reversed edge arrays to easily find the
+        // in-neighbors for each vertex. We will use the SRC_R and DST_R components below to 
+        // signify the reversed edge arrays as well as a SEGMENTS_R array defined here. 
+        SEGMENTS_R,
+
         // TEMPORARY COMPONENTS BELOW FOR UNDIRECTED GRAPHS TO ENSURE COMPATIBILTIY WITH OLD CODE.
         // We want to phase out the need for reversed arrays in undirected graph algorithms.
         // Includes: connected components, triangle counting, k-truss, and triangle centrality.


### PR DESCRIPTION
Directed graphs now also store reversed arrays to find in-neighbors in constant time by using the three components `SRC_R`, `DST_R`, and `SEGMENTS_R` in the `SegGraph` class. 