### PR TITLE
fixes fastLocalSubdomain

### DIFF
--- a/arachne/server/BuildPropertyGraph.chpl
+++ b/arachne/server/BuildPropertyGraph.chpl
@@ -2,6 +2,7 @@ module BuildPropertyGraph {
     // Chapel modules.
     use Map;
     use BlockDist;
+    use ChplConfig;
     
     // Arachne Modules.
     use GraphArray;
@@ -218,7 +219,8 @@ module BuildPropertyGraph {
                         attributeMap.add(attributeName, (dataArraySymTabId, dataArrayType));
                     } else {
                         // TODO: Future work, handle nonconsecutive arrays.
-                        var temp = blockDist.createArray({0..1}, int);
+                        var D = {0..1};
+                        var temp = if CHPL_COMM != "none" then blockDist.createArray(D, int) else D.tryCreateArray(int);
                         var dataArrayRegEntry = (st.registry.tab(dataArraySymTabId)):shared CategoricalRegEntry;
                         var categories = getSegString(dataArrayRegEntry.categories, st);
                         var codes = toSymEntry(getGenericTypedArrayEntry(dataArrayRegEntry.codes, st), int).a;

--- a/arachne/server/Utils.chpl
+++ b/arachne/server/Utils.chpl
@@ -12,12 +12,15 @@ module Utils {
     use MultiTypeSymbolTable;
 
     /* A fast variant of localSubdomain() assumes 'blockArray' is a block-distributed array
-       if it breaks, replace it with:
+        if it breaks, replace it with:
             inline proc fastLocalSubdomain(arr) do return arr.localSubdomain();*/
-    proc fastLocalSubdomain(const ref blockArray) const ref {
-        assert(blockArray.targetLocales()[here.id] == here);
-        return blockArray._value.dom.locDoms[here.id].myBlock;
-    }
+    // proc fastLocalSubdomain(const ref blockArray) const ref {
+    //     assert(blockArray.targetLocales()[here.id] == here);
+    //     return blockArray._value.dom.locDoms[here.id].myBlock;
+    // }
+    // NOTE: Temporary fix, waiting to hear back from Chapel developers on how to pick between 
+    //       functions at compile-time.
+    inline proc fastLocalSubdomain(arr) do return arr.localSubdomain();
 
     /* Extract the integer identifier for an edge `<u,v>`. TODO: any function that queries into the 
     graph data structure should probably be a class method of SegGraph.


### PR DESCRIPTION
Fixes compilation error when `CHPL_COMM` is `none` thrown by `fastLocalSubdomain()`.
Fixes type casting when distributed arrays when a regular array is needed instead.