### PR TITLE
Fixed `vertexPicker()` and `edgePicker()`

### DIFF
--- a/arachne/subgraph_matching_with_random_graphs_sample.ipynb
+++ b/arachne/subgraph_matching_with_random_graphs_sample.ipynb
@@ -2,25 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "f651e065",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    _         _                   _       \n",
-      "   / \\   _ __| | _____  _   _  __| | __ _ \n",
-      "  / _ \\ | '__| |/ / _ \\| | | |/ _` |/ _` |\n",
-      " / ___ \\| |  |   < (_) | |_| | (_| | (_| |\n",
-      "/_/   \\_\\_|  |_|\\_\\___/ \\__,_|\\__,_|\\__,_|\n",
-      "                                          \n",
-      "\n",
-      "Client Version: v2024.06.21+0.gcf6eeacde.dirty\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import arkouda as ak\n",
     "import arachne as ar\n",
@@ -32,32 +17,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "671cb378",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "connected to arkouda server tcp://*:5555\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# NOTE: Make sure to change the server name to whatever is applicable in your environment. If running locally, then use only ak.connect().\n",
-    "ak.connect(\"n31\", 5555)"
+    "ak.connect(\"n113\", 5555)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "e0ab4242",
    "metadata": {},
    "outputs": [],
    "source": [
-    "n = 100_000\n",
-    "m = 100_000_000\n",
+    "n = 100\n",
+    "m = 1000\n",
     "s = 2\n",
     "x = 2\n",
     "y = 2"
@@ -65,18 +42,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "36d90c88",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Building property graph with 100000 vertices and 99500951 edges took 5.96 seconds.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import time\n",
     "\n",
@@ -135,112 +104,89 @@
     "labels1_subgraph = ak.array([\"lbl1\", \"lbl1\", \"lbl1\", \"lbl1\"])\n",
     "labels2_subgraph = ak.array([\"lbl3\", \"lbl3\", \"lbl3\", \"lbl3\"])\n",
     "rels1_subgraph = ak.array([\"rel1\", \"rel1\", \"rel1\", \"rel1\", \"rel1\"])\n",
-    "rels2_subgraph = ak.array([\"rel3\", \"rel3\", \"rel3\", \"rel3\", \"rel3\"])\n",
-    "\n",
-    "#2. Populate the subgraph.\n",
-    "subgraph = ar.PropGraph()\n",
-    "edge_df_h = ak.DataFrame({\"src\":src_subgraph, \"dst\":dst_subgraph,\n",
-    "                        \"rels1\":rels1_subgraph, \"rels2\":rels2_subgraph})\n",
-    "node_df_h = ak.DataFrame({\"nodes\": ak.array(subgraph_nodes), \"lbls1\":labels1_subgraph,\n",
-    "                          \"lbls2\":labels2_subgraph})\n",
-    "subgraph.load_edge_attributes(edge_df_h, source_column=\"src\", destination_column=\"dst\",\n",
-    "                                relationship_columns=[\"rels1\",\"rels2\"])"
+    "rels2_subgraph = ak.array([\"rel3\", \"rel3\", \"rel3\", \"rel3\", \"rel3\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "66c3bc99",
+   "execution_count": null,
+   "id": "d176e508",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "We found 658.0 isos inside of the graph\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "\"\"\"TEST VERTEX PICKER\"\"\"\n",
+    "subgraph = ar.PropGraph()\n",
+    "edge_df_h = ak.DataFrame({\"src\":src_subgraph, \"dst\":dst_subgraph})\n",
+    "node_df_h = ak.DataFrame({\"nodes\": ak.array(subgraph_nodes), \"lbls1\":labels1_subgraph,\n",
+    "                          \"lbls2\":labels2_subgraph})\n",
+    "subgraph.load_edge_attributes(edge_df_h, source_column=\"src\", destination_column=\"dst\")\n",
+    "subgraph.load_node_attributes(node_df_h, node_column = \"nodes\", \n",
+    "                                label_columns = [\"lbls1\",\"lbls2\"])\n",
+    "\n",
     "isos_as_vertices = ar.subgraph_isomorphism(prop_graph, subgraph, \n",
-    "                                           semantic_check=\"or\", algorithm_type=\"si\", \n",
-    "                                           return_isos_as=\"vertices\", size_limit = 500\n",
+    "                                           semantic_check=\"or\", algorithm_type=\"si\", return_isos_as=\"vertices\"\n",
     ")\n",
     "print(f\"We found {len(isos_as_vertices[0])/len(subgraph)} isos inside of the graph\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "dbaca18c",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "We found 16487961.0 isos inside of the graph\n"
-     ]
-    }
-   ],
-   "source": [
-    "isos_as_edges = ar.subgraph_isomorphism(prop_graph, subgraph, \n",
-    "                                        semantic_check=\"or\", algorithm_type=\"si\", \n",
-    "                                        return_isos_as=\"edges\", time_limit=2\n",
-    ")\n",
-    "print(f\"We found {len(isos_as_edges[0])/subgraph.size()} isos inside of the graph\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "a1c751a2",
+   "execution_count": null,
+   "id": "f4c138bc",
    "metadata": {},
    "outputs": [],
    "source": [
-    "subgraph.load_node_attributes(node_df_h, node_column=\"nodes\", label_columns=[\"lbls1\",\"lbls2\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "4ed0ac8b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "We found 16099278.0 isos inside of the graph\n"
-     ]
-    }
-   ],
-   "source": [
-    "isos_as_edges = ar.subgraph_isomorphism(prop_graph, subgraph, \n",
-    "                                        semantic_check=\"or\", algorithm_type=\"si\", \n",
-    "                                        return_isos_as=\"edges\", time_limit=2\n",
-    ")\n",
-    "print(f\"We found {len(isos_as_edges[0])/subgraph.size()} isos inside of the graph\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "644401cb",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "We found 766.0 isos inside of the graph\n"
-     ]
-    }
-   ],
-   "source": [
+    "\"\"\"TEST EDGE PICKER\"\"\"\n",
+    "subgraph = ar.PropGraph()\n",
+    "edge_df_h = ak.DataFrame({\"src\":src_subgraph, \"dst\":dst_subgraph,\n",
+    "                        \"rels1\":rels1_subgraph, \"rels2\":rels2_subgraph})\n",
+    "subgraph.load_edge_attributes(edge_df_h, source_column=\"src\", destination_column=\"dst\",\n",
+    "                                relationship_columns=[\"rels1\",\"rels2\"])\n",
+    "\n",
     "isos_as_vertices = ar.subgraph_isomorphism(prop_graph, subgraph, \n",
-    "                                           semantic_check=\"or\", algorithm_type=\"si\", \n",
-    "                                           return_isos_as=\"vertices\", size_limit = 500\n",
+    "                                           semantic_check=\"or\", algorithm_type=\"si\", return_isos_as=\"vertices\"\n",
+    ")\n",
+    "print(f\"We found {len(isos_as_vertices[0])/len(subgraph)} isos inside of the graph\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36aa6159",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"TEST COMBINED PICKER\"\"\"\n",
+    "subgraph = ar.PropGraph()\n",
+    "edge_df_h = ak.DataFrame({\"src\":src_subgraph, \"dst\":dst_subgraph,\n",
+    "                        \"rels1\":rels1_subgraph, \"rels2\":rels2_subgraph})\n",
+    "node_df_h = ak.DataFrame({\"nodes\": ak.array(subgraph_nodes), \"lbls1\":labels1_subgraph,\n",
+    "                          \"lbls2\":labels2_subgraph})\n",
+    "subgraph.load_edge_attributes(edge_df_h, source_column=\"src\", destination_column=\"dst\",\n",
+    "                                relationship_columns=[\"rels1\",\"rels2\"])\n",
+    "subgraph.load_node_attributes(node_df_h, node_column = \"nodes\", \n",
+    "                                label_columns=[\"lbls1\",\"lbls2\"])\n",
+    "\n",
+    "isos_as_vertices = ar.subgraph_isomorphism(prop_graph, subgraph, \n",
+    "                                           semantic_check=\"or\", algorithm_type=\"si\", return_isos_as=\"vertices\"\n",
+    ")\n",
+    "print(f\"We found {len(isos_as_vertices[0])/len(subgraph)} isos inside of the graph\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e49df46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"TEST NO PICKER\"\"\"\n",
+    "subgraph = ar.PropGraph()\n",
+    "edge_df_h = ak.DataFrame({\"src\":src_subgraph, \"dst\":dst_subgraph})\n",
+    "subgraph.load_edge_attributes(edge_df_h, source_column=\"src\", destination_column=\"dst\")\n",
+    "\n",
+    "isos_as_vertices = ar.subgraph_isomorphism(prop_graph, subgraph, \n",
+    "                                           semantic_check=\"or\", algorithm_type=\"si\", return_isos_as=\"vertices\"\n",
     ")\n",
     "print(f\"We found {len(isos_as_vertices[0])/len(subgraph)} isos inside of the graph\")"
    ]


### PR DESCRIPTION
While developing a switching mechanism between subgraph isomorphism and monomorphism, a bug was found that was forcing the `edgePicker()` to still behave like the `vertexPicker()` by tracking the vertex indices of the edges that matched the attributes the user was looking for. However, the purpose was to track the edges, NOT the vertices. 